### PR TITLE
fix: use class inside child to prevent vue warning

### DIFF
--- a/components/EditorCategory.vue
+++ b/components/EditorCategory.vue
@@ -7,12 +7,7 @@ import {
   PaintBrushIcon,
 } from "@heroicons/vue/24/outline";
 
-const {
-  class: classList,
-  id,
-  isHidden,
-} = defineProps<{
-  class: string;
+const { id, isHidden } = defineProps<{
   id: string;
   isHidden?: boolean;
 }>();
@@ -26,10 +21,7 @@ function toggleDisplay() {
 </script>
 
 <template>
-  <div
-    :id="id"
-    :class="`flex flex-col bg-white bg-opacity-10 rounded ${classList ?? ''}`"
-  >
+  <div :id="id" class="flex flex-col bg-white bg-opacity-10 rounded w-full">
     <header
       :class="`p-6 flex justify-between items-center rounded bg-white ${isHidden ? 'bg-opacity-0 border border-white/10' : 'bg-opacity-100'} text-pink-500 shadow-lg`"
     >

--- a/fragments/LetterBodyEditor.vue
+++ b/fragments/LetterBodyEditor.vue
@@ -20,7 +20,7 @@ function addParagraph() {
 </script>
 
 <template>
-  <EditorCategory id="Body" class="w-full">
+  <EditorCategory id="Body">
     <template v-slot:header>Body</template>
     <template v-slot:style>
       <ul class="flex flex-col gap-10 mb-4">

--- a/fragments/LetterCustomizationEditor.vue
+++ b/fragments/LetterCustomizationEditor.vue
@@ -61,7 +61,7 @@ watch(
 </script>
 
 <template>
-  <EditorCategory id="Customization" class="w-full">
+  <EditorCategory id="Customization">
     <template v-slot:header>Customization</template>
     <ul class="flex flex-col gap-10 mb-4">
       <li class="border-b-2 border-white border-opacity-5 pb-12">

--- a/fragments/LetterHeaderEditor.vue
+++ b/fragments/LetterHeaderEditor.vue
@@ -36,7 +36,7 @@ function addSenderDetail() {
 </script>
 
 <template>
-  <EditorCategory id="Header" class="w-full">
+  <EditorCategory id="Header">
     <template v-slot:header>Header</template>
     <template v-slot:style>
       <ul class="flex flex-col gap-10 mb-4">

--- a/fragments/PersonalDetailsEditor.vue
+++ b/fragments/PersonalDetailsEditor.vue
@@ -43,7 +43,7 @@ function changeContactDetaiType(
 </script>
 
 <template>
-  <EditorCategory id="Details" class="w-full">
+  <EditorCategory id="Details">
     <template v-slot:header>Details</template>
     <div class="flex flex-col gap-5">
       <label class="flex flex-col" for="detailsName">

--- a/fragments/ResumeCategoriesEditor.vue
+++ b/fragments/ResumeCategoriesEditor.vue
@@ -112,7 +112,6 @@ function toggleCategoryVisibility(category: Category) {
 
 <template>
   <EditorCategory
-    class="w-full"
     v-for="(category, categoryIndex) in categories"
     :key="categoryIndex"
     :id="category.name"

--- a/fragments/ResumeCustomizationEditor.vue
+++ b/fragments/ResumeCustomizationEditor.vue
@@ -59,7 +59,7 @@ watch(
 </script>
 
 <template>
-  <EditorCategory id="Customization" class="w-full">
+  <EditorCategory id="Customization">
     <template v-slot:header>Customization</template>
     <ul class="flex flex-col gap-10 mb-4">
       <li class="border-b-2 border-white border-opacity-5 pb-12">


### PR DESCRIPTION
Un warning de vue. Dommage, c'est au parent de gérer la largeur.