### PR TITLE
feat: allow mansonry layout

### DIFF
--- a/components/ResumeBody.vue
+++ b/components/ResumeBody.vue
@@ -220,7 +220,8 @@ const bodyCategories = computed(() =>
       </div>
     </aside>
     <div
-      class="grid grid-cols-2 flex-1"
+      class="flex-1"
+      :class="settings.category.isMansonry ? 'columns-2' : 'grid grid-cols-2'"
       :style="{
         ...getNodeStyle(settings.body, 'block'),
         gap: `${settings.category.gap}px`,
@@ -228,11 +229,15 @@ const bodyCategories = computed(() =>
     >
       <section
         v-if="isHeaderSimple && !asideCategories.length"
+        class="break-inside-avoid"
         :class="
-          bodyCategories[0]?.layout === 'half' ? 'col-span-1' : 'col-span-2'
+          getCategoryLayoutClass(
+            bodyCategories[0],
+            settings.category.isMansonry,
+          )
         "
         :style="{
-          display: settings.categoryName.isAside ? 'flex' : 'initial',
+          display: settings.categoryName.isAside ? 'flex' : 'block',
           ...getNodeStyle(settings.category, 'block'),
         }"
       >
@@ -265,9 +270,10 @@ const bodyCategories = computed(() =>
       <section
         v-for="(category, categoryIndex) in bodyCategories"
         :key="categoryIndex"
-        :class="category.layout === 'half' ? 'col-span-1' : 'col-span-2'"
+        class="break-inside-avoid"
+        :class="getCategoryLayoutClass(category, settings.category.isMansonry)"
         :style="{
-          display: settings.categoryName.isAside ? 'flex' : 'initial',
+          display: settings.categoryName.isAside ? 'flex' : 'block',
           ...getNodeStyle(settings.category, 'block'),
         }"
       >

--- a/fragments/StyleEditor.vue
+++ b/fragments/StyleEditor.vue
@@ -534,6 +534,15 @@ function askBeforeResetStyle() {
         <Fieldset :legend="capitalize($t('category'))" toggleable>
           <div class="formBlock">
             <Field
+              id="categoryIsMansonry"
+              :label="$t('mansonry')"
+              type="checkbox"
+              v-model="resumeSettings.category.isMansonry"
+            />
+            <Message v-if="resumeSettings.category.isMansonry" size="small">
+              {{ t("howToGapMansonry") }}
+            </Message>
+            <Field
               id="categoryGap"
               :label="$t('gap')"
               type="number"
@@ -701,23 +710,28 @@ function askBeforeResetStyle() {
 {
   "br": {
     "onLabel": "TODO",
-    "offLabel": "TODO"
+    "offLabel": "TODO",
+    "howToGapMansonry": "TODO"
   },
   "de": {
     "onLabel": "angepasst",
-    "offLabel": "nicht angepasst"
+    "offLabel": "nicht angepasst",
+    "howToGapMansonry": "TODO"
   },
   "en": {
     "onLabel": "customized",
-    "offLabel": "not customized"
+    "offLabel": "not customized",
+    "howToGapMansonry": "Vertical gap is handled with category top and bottom margins."
   },
   "es": {
     "onLabel": "TODO",
-    "offLabel": "TODO"
+    "offLabel": "TODO",
+    "howToGapMansonry": "TODO"
   },
   "fr": {
     "onLabel": "modifié",
-    "offLabel": "non modifié"
+    "offLabel": "non modifié",
+    "howToGapMansonry": "L'espacement vertical est géré avec les marges haute et basse de la catégorie."
   }
 }
 </i18n>

--- a/globals/index.ts
+++ b/globals/index.ts
@@ -256,6 +256,7 @@ export const resumeSettings: ResumeSettings = {
     border: [0, 0, 0, 0],
     padding: [0, 0, 0, 0],
     gap: 12,
+    isMansonry: false,
   },
   categoryName: {
     font: "inherit",

--- a/types/index.ts
+++ b/types/index.ts
@@ -184,6 +184,7 @@ export type ResumeSettings = PaperDocumentSettings & {
     };
   body: BlockSettings;
   category: BlockSettings & {
+    isMansonry: false;
     gap: number; // Flex gap between categories
   };
   categoryName: BlockSettings &

--- a/utils/style.ts
+++ b/utils/style.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import type { StyleValue } from "vue";
+import type { Category } from "~/types";
 // import type { ResumeSettings } from "@/types";
 
 // type Keys = keyof ResumeSettings;
@@ -68,4 +69,17 @@ export function getNodeStyle(
  */
 export function getNodeClass(id: string, focusedInput: string | undefined) {
   return focusedInput === id ? "!border-4 !border-double !border-primary" : "";
+}
+
+/**
+ * Use the correct column properties whether layout is mansonry (native columns) or not (grid columns).
+ */
+export function getCategoryLayoutClass(
+  category?: Category,
+  isMansonry: boolean,
+) {
+  if (category?.layout === "half") {
+    return isMansonry ? "[column-span:none]" : "col-span-1";
+  }
+  return isMansonry ? "[column-span:all]" : "col-span-2";
 }


### PR DESCRIPTION
Deux stratégies :
1. on merge en l'état (avec du code pour pallier le manque de mansonry natif, qu'il faudra supprimer à terme)
2. on attend que [la spec mansonry ](https://developer.mozilla.org/fr/docs/Web/CSS/CSS_grid_layout/Masonry_layout) soit dispo nativement

Le mansonry c'est ce qui permet d'avoir des blocs qui prennent l'espace disponibles lorsque les blocs précédents n'ont pas la même hauteur (voir l'exemple de cette page : https://tailwindcss.com/docs/columns)